### PR TITLE
Add fetch event for test mocking

### DIFF
--- a/src/events/FetchEvent.php
+++ b/src/events/FetchEvent.php
@@ -1,0 +1,18 @@
+<?php
+namespace verbb\consume\events;
+
+use craft\events\CancelableEvent;
+
+class FetchEvent extends CancelableEvent
+{
+    // Properties
+    // =========================================================================
+
+    public array|string $clientOpts;
+    public string $method;
+    public string $uri;
+    public array $options;
+
+    public mixed $response = null;
+
+}

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -3,6 +3,7 @@ namespace verbb\consume\services;
 
 use verbb\consume\Consume;
 use verbb\consume\base\OAuthClient;
+use verbb\consume\events\FetchEvent;
 use verbb\consume\models\Settings;
 
 use Craft;
@@ -18,6 +19,7 @@ use DateTimeZone;
 use Exception;
 use Throwable;
 
+use yii\base\Event;
 use yii\caching\TagDependency;
 
 use verbb\auth\helpers\UrlHelper as AuthUrlHelper;
@@ -27,11 +29,28 @@ use Symfony\Component\Serializer\Encoder\XmlEncoder;
 
 class Service extends Component
 {
+    // Constants
+    // =========================================================================
+    public const EVENT_BEFORE_FETCH_DATA = 'beforeFetchData';
+
     // Public Methods
     // =========================================================================
 
     public function fetchData(array|string $clientOpts, string $method = 'GET', string $uri = '', array $options = []): mixed
     {
+        $event = new FetchEvent([
+            'clientOpts' => $clientOpts,
+            'method' => $method,
+            'uri' => $uri,
+            'options' => $options,
+        ]);
+
+        Event::trigger(self::class, self::EVENT_BEFORE_FETCH_DATA, $event);
+
+        if (! $event->isValid) {
+            return $event->response;
+        }
+
         $settings = Consume::$plugin->getSettings();
 
         // Allow overriding cache/duration in templates
@@ -130,6 +149,7 @@ class Service extends Component
 
             return $this->_parseResponse($format, $response);
         } catch (Throwable $e) {
+            \markhuot\craftpest\helpers\test\dd($e);
             Consume::error('Unable to fetch data: “{message}” {file}:{line}. Trace: “{trace}”.', [
                 'message' => $e->getMessage(),
                 'file' => $e->getFile(),

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -149,7 +149,6 @@ class Service extends Component
 
             return $this->_parseResponse($format, $response);
         } catch (Throwable $e) {
-            \markhuot\craftpest\helpers\test\dd($e);
             Consume::error('Unable to fetch data: “{message}” {file}:{line}. Trace: “{trace}”.', [
                 'message' => $e->getMessage(),
                 'file' => $e->getFile(),


### PR DESCRIPTION
This adds a hook/event at the beginning of `fetchData` that would allow external processing to usurp the entire call. I'm using this for test mocking, where we're integrating with a bad API I can't hit from CI. So I match against the request and conditionally return static data instead. My listener looks something like the below (for reference only).

```php
Event::on(
    Service::class,
    Service::EVENT_BEFORE_FETCH_DATA,
    function (FetchEvent $event) {
        $parts = parse_url($event->uri);

        $mocks = [
            ['method' => 'get', 'path' => '#^podcasts$#', 'response' => 'podcasts.json'],
            ['method' => 'get', 'path' => '#^podcasts/([a-z0-9-]+)/seasons$#', 'response' => 'seasons.json'],
            ['method' => 'get', 'path' => '#^podcasts/([a-z0-9-]+)/episodes#', 'response' => 'episode-count.json'],
            ['method' => 'post', 'path' => '#^podcasts/([a-z0-9-]+)/episodes$#', 'response' => 'create-episode.json'],
            ['method' => 'get', 'path' => '#^episodes/([a-z0-9-]+)$#', 'response' => 'episode.json'],
            ['method' => 'post', 'path' => '#^episodes/([a-z0-9-]+)/audio$#', 'response' => 'create-placeholder.json'],
            ['method' => 'put', 'host' => '#^s3.amazonaws.com$#', 'response' => 'upload-audio.json'],
        ];

        foreach ($mocks as $mock) {
            if (! empty($mock['method']) && $mock['method'] !== strtolower($event->method)) {
                continue;
            }
            if (! empty($mock['path']) && preg_match($mock['path'], $parts['path']) == false) {
                continue;
            }
            if (! empty($mock['domain']) && preg_match($mock['host'], $parts['host']) == false) {
                continue;
            }

            $event->isValid = false;
            $event->response = json_decode(file_get_contents(CRAFT_BASE_PATH . '/tests/mocks/simplecast/' . $mock['response']), true, 512, JSON_THROW_ON_ERROR);
            return;
        }

        throw new \RuntimeException('Unexpected remote call made during tests');
    }
);
```