### PR TITLE
Add headless support for auth callback

### DIFF
--- a/src/Consume.php
+++ b/src/Consume.php
@@ -100,6 +100,7 @@ class Consume extends Plugin
             $event->rules['consume/clients/oauth/new'] = 'consume/clients/edit-oauth';
             $event->rules['consume/clients/oauth/<handle:{handle}>'] = 'consume/clients/edit-oauth';
             $event->rules['consume/settings'] = 'consume/plugin/settings';
+            $event->rules['consume/auth/callback'] = 'consume/auth/callback';
         });
     }
 

--- a/src/Consume.php
+++ b/src/Consume.php
@@ -100,7 +100,9 @@ class Consume extends Plugin
             $event->rules['consume/clients/oauth/new'] = 'consume/clients/edit-oauth';
             $event->rules['consume/clients/oauth/<handle:{handle}>'] = 'consume/clients/edit-oauth';
             $event->rules['consume/settings'] = 'consume/plugin/settings';
-            $event->rules['consume/auth/callback'] = 'consume/auth/callback';
+            if (Craft::$app->config->general->headlessMode) {
+                $event->rules['consume/auth/callback'] = 'consume/auth/callback';
+            }
         });
     }
 

--- a/src/base/OAuthClient.php
+++ b/src/base/OAuthClient.php
@@ -35,7 +35,7 @@ abstract class OAuthClient extends Client implements OAuthProviderInterface
     // =========================================================================
 
     use OAuthProviderTrait;
-    
+
 
     // Public Methods
     // =========================================================================
@@ -86,6 +86,11 @@ abstract class OAuthClient extends Client implements OAuthProviderInterface
     public function getRedirectUri(): ?string
     {
         $siteId = Craft::$app->getSites()->getPrimarySite()->id;
+
+        // If headless mode is enabled, we should use the CP URL
+        if (Craft::$app->config->general->headlessMode) {
+            return UrlHelper::cpUrl('consume/auth/callback', null, null, $siteId);
+        }
 
         // We should always use the primary site for the redirect
         return UrlHelper::siteUrl('consume/auth/callback', null, null, $siteId);


### PR DESCRIPTION
In some headless setups, the primary site url can be pointing to another domain. That breaks the OAuthClient because it tries to redirect to the primary site url.

This adds a `headlessMode` configuration check that allows for the route `consume/auth/callback` to be available in the control panel.

