### PR TITLE
Docs: Update Google provider to use plugin name correctly.

### DIFF
--- a/docs/providers/all-providers.md
+++ b/docs/providers/all-providers.md
@@ -525,7 +525,7 @@ Follow the below steps to connect to the Google API.
 1. Next, go to the **APIs & Services** → **Credentials** section.
 1. Click **Create Credentials** → **OAuth client ID**.
     1. On the following page, select the **Application Type** as **Web application**.
-    1. Provide a suitable **Name** so you can identify it in your Google account. This is not required by {plugin}.
+    1. Provide a suitable **Name** so you can identify it in your Google account. This is not required by Consume.
     1. Under the **Authorized JavaScript origins**, click **Add URI** and enter your project's Site URL.
     1. Under the **Authorized redirect URIs**, click **Add URI** and enter the value from the **Redirect URI** field in Consume.
     1. Then click the **Create** button.


### PR DESCRIPTION
There is `{plugin}` reference, which is maybe a placeholder/reference but has been updated to use "Consume" directly.