### PR TITLE
Fix doc link for local proxy testing for Google provider

### DIFF
--- a/src/templates/clients/oauth/_types/google.html
+++ b/src/templates/clients/oauth/_types/google.html
@@ -5,7 +5,7 @@
 
 {{ macros.proxyField(fieldVariables, 'booleanMenuField', {
     label: 'Proxy Redirect URI' | t('consume'),
-    instructions: 'Whether to proxy the redirect URI through Verbb‘s servers. This should **only** be used for local testing. See [docs](https://verbb.io/craft-plugins/consume/docs/feature-tour/clients#local-testing-proxy) for more.' | t('consume') | md,
+    instructions: 'Whether to proxy the redirect URI through Verbb‘s servers. This should **only** be used for local testing. See [docs](https://verbb.io/craft-plugins/consume/docs/providers/all-providers#local-testing-proxy) for more.' | t('consume') | md,
     name: 'proxyRedirect',
     includeEnvVars: true,
     value: client.proxyRedirect ?? false,


### PR DESCRIPTION
This updates the doc link on the local proxy testing boolean field for the Google OAuth provider.